### PR TITLE
Start xvfb using 'services' rather than a run script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ before_script:
   - sudo apt-get update
   - sudo apt-get install python3-dev
   - if [ $CI_TARGET = vim ]; then
-      sudo apt-get install vim-gnome &&
-      export DISPLAY=:99.0 &&
-      sh -e /etc/init.d/xvfb start;
+      sudo apt-get install vim-gnome;
     elif [ $CI_TARGET = neovim ]; then
       eval "$(curl -Ss https://raw.githubusercontent.com/neovim/bot-ci/master/scripts/travis-setup.sh) nightly-x64" &&
       wget https://bootstrap.pypa.io/get-pip.py &&
@@ -20,6 +18,8 @@ before_script:
   - sudo dpkg -i ./vroom_0.12.0-1_all.deb
   - git clone -b ${MAKTABA_VERSION} https://github.com/google/vim-maktaba.git ../maktaba/
   - git clone https://github.com/google/vim-glaive.git ../glaive/
+services:
+  - xvfb
 script:
   - '[ $CI_TARGET = neovim ] && VROOM_ARGS="--neovim" || VROOM_ARGS=""'
   - vroom $VROOM_ARGS --crawl ./vroom/


### PR DESCRIPTION
This is necessary now that Travis has switched from Trusty to Xenial by default.

(See https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services)