### PR TITLE
Ignore global maps when processing selector keys

### DIFF
--- a/autoload/selector.vim
+++ b/autoload/selector.vim
@@ -434,7 +434,7 @@ function! s:InstantiateKeyMaps(mappings) abort
   for l:scrubbed_key in keys(a:mappings)
     let l:items = a:mappings[l:scrubbed_key]
     let l:actual_key = l:items[3]
-    let l:mapping = 'nnoremap <buffer> <silent> ' . l:actual_key
+    let l:mapping = 'nnoremap <buffer> <silent> <nowait> ' . l:actual_key
         \ . " :call selector#KeyCall('" . l:scrubbed_key . "')<CR>"
     execute l:mapping
   endfor


### PR DESCRIPTION
Process key maps without waiting for longer global mappings that
start with the same keys.