### PR TITLE
Avoid setting global nomodifiable in selector help

### DIFF
--- a/autoload/selector.vim
+++ b/autoload/selector.vim
@@ -425,8 +425,8 @@ function! selector#DoToggleHelp() dict abort
   let l:len_help = len(self._GetHelpLines())
   let self._is_verbose = !self._is_verbose
   call maktaba#buffer#Overwrite(1, l:len_help, self._GetHelpLines())
-  let &readonly = l:prev_read
-  let &modifiable = l:prev_mod
+  let &l:readonly = l:prev_read
+  let &l:modifiable = l:prev_mod
 endfunction
 
 " Initialize the key bindings

--- a/autoload/selector.vim
+++ b/autoload/selector.vim
@@ -418,15 +418,13 @@ endfunction
 " Toggle whether verbose help is shown for the selector.
 function! selector#DoToggleHelp() dict abort
   " TODO(dbarnett): Don't modify buffer if none exists.
-  let l:prev_read = &readonly
-  let l:prev_mod = &modifiable
   setlocal noreadonly
   setlocal modifiable
   let l:len_help = len(self._GetHelpLines())
   let self._is_verbose = !self._is_verbose
   call maktaba#buffer#Overwrite(1, l:len_help, self._GetHelpLines())
-  let &l:readonly = l:prev_read
-  let &l:modifiable = l:prev_mod
+  setlocal readonly
+  setlocal nomodifiable
 endfunction
 
 " Initialize the key bindings


### PR DESCRIPTION
## problem

Using the help menu `H` in selector window sets global nomodifiable option.
Files opened from the selector menu are then locked for editing.

## solution

Restore nomodifiable option locally so it only applies to the selector window.